### PR TITLE
28870 allow task listener to provide reason to deny passing response rejection

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -41,13 +41,13 @@ import java.util.Optional;
 public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private static final String USER_TASK_COMPLETION_REJECTION =
-      "Completion of the User Task with key '%d' was denied by Task Listener";
+      "Completion of the User Task with key '%d' was denied by Task Listener. Reason to deny: '%s'";
 
   private static final String USER_TASK_ASSIGNMENT_REJECTION =
-      "Assignment of the User Task with key '%d' was denied by Task Listener";
+      "Assignment of the User Task with key '%d' was denied by Task Listener. Reason to deny: '%s'";
 
   private static final String USER_TASK_UPDATE_REJECTION =
-      "Update of the User Task with key '%d' was denied by Task Listener";
+      "Update of the User Task with key '%d' was denied by Task Listener. Reason to deny: '%s'";
 
   private final UserTaskCommandProcessors commandProcessors;
   private final ProcessState processState;
@@ -252,7 +252,8 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
               command.getValue(),
               command.getValueType(),
               RejectionType.INVALID_STATE,
-              mapDeniedIntentToResponseRejectionReason(intent, persistedRecord.getUserTaskKey()),
+              mapDeniedIntentToResponseRejectionReason(
+                  intent, persistedRecord.getUserTaskKey(), command.getValue().getDeniedReason()),
               metadata.getRequestId(),
               metadata.getRequestStreamId());
         });
@@ -301,11 +302,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   }
 
   private String mapDeniedIntentToResponseRejectionReason(
-      final UserTaskIntent intent, final long userTaskKey) {
+      final UserTaskIntent intent, final long userTaskKey, final String deniedReason) {
     return switch (intent) {
-      case COMPLETION_DENIED -> USER_TASK_COMPLETION_REJECTION.formatted(userTaskKey);
-      case ASSIGNMENT_DENIED -> USER_TASK_ASSIGNMENT_REJECTION.formatted(userTaskKey);
-      case UPDATE_DENIED -> USER_TASK_UPDATE_REJECTION.formatted(userTaskKey);
+      case COMPLETION_DENIED -> USER_TASK_COMPLETION_REJECTION.formatted(userTaskKey, deniedReason);
+      case ASSIGNMENT_DENIED -> USER_TASK_ASSIGNMENT_REJECTION.formatted(userTaskKey, deniedReason);
+      case UPDATE_DENIED -> USER_TASK_UPDATE_REJECTION.formatted(userTaskKey, deniedReason);
       default ->
           throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -18,6 +18,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.AssignUserTaskResponse;
 import io.camunda.client.api.response.CompleteUserTaskResponse;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
@@ -296,7 +297,14 @@ public class UserTaskListenersTest {
             t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
 
     final JobHandler completeJobWithDenialHandler =
-        (jobClient, job) -> client.newCompleteCommand(job).withResult().deny(true).send().join();
+        (jobClient, job) ->
+            client
+                .newCompleteCommand(job)
+                .withResult()
+                .deny(true)
+                .denyReason("Reason to deny lifecycle transition")
+                .send()
+                .join();
     client.newWorker().jobType(listenerType).handler(completeJobWithDenialHandler).open();
 
     // when: invoke `UPDATE` user task command
@@ -306,12 +314,17 @@ public class UserTaskListenersTest {
     // then: TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
         listenerType,
-        userTaskListener -> assertThat(userTaskListener.getResult().isDenied()).isTrue());
+        userTaskListener -> {
+          assertThat(userTaskListener.getResult().isDenied()).isTrue();
+          assertThat(userTaskListener.getResult().getDeniedReason())
+              .isEqualTo("Reason to deny lifecycle transition");
+        });
 
-    // and: verify the rejection
+    // and: verify the rejection and rejection reason
     final var rejectionReason =
         String.format(
-            "Command 'UPDATE' rejected with code 'INVALID_STATE': Update of the User Task with key '%s' was denied by Task Listener",
+            "Command 'UPDATE' rejected with code 'INVALID_STATE': Update of the User Task with key '%s' was denied by Task Listener. "
+                + "Reason to deny: 'Reason to deny lifecycle transition'",
             userTaskKey);
     assertThatExceptionOfType(ProblemException.class)
         .isThrownBy(updateUserTaskFuture::join)
@@ -336,7 +349,14 @@ public class UserTaskListenersTest {
             t -> t.zeebeTaskListener(l -> l.completing().type(listenerType)));
 
     final JobHandler completeJobHandler =
-        (jobClient, job) -> client.newCompleteCommand(job).withResult().deny(true).send().join();
+        (jobClient, job) ->
+            client
+                .newCompleteCommand(job)
+                .withResult()
+                .deny(true)
+                .denyReason("Reason to deny lifecycle transition")
+                .send()
+                .join();
     final var recordingHandler = new RecordingJobHandler(completeJobHandler);
 
     client.newWorker().jobType(listenerType).handler(recordingHandler).open();
@@ -348,11 +368,16 @@ public class UserTaskListenersTest {
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
         listenerType,
-        userTaskListener -> assertThat(userTaskListener.getResult().isDenied()).isTrue());
+        userTaskListener -> {
+          assertThat(userTaskListener.getResult().isDenied()).isTrue();
+          assertThat(userTaskListener.getResult().getDeniedReason())
+              .isEqualTo("Reason to deny lifecycle transition");
+        });
 
     final var rejectionReason =
         String.format(
-            "Command 'COMPLETE' rejected with code 'INVALID_STATE': Completion of the User Task with key '%s' was denied by Task Listener",
+            "Command 'COMPLETE' rejected with code 'INVALID_STATE': Completion of the User Task with key '%s' was denied by Task Listener. "
+                + "Reason to deny: 'Reason to deny lifecycle transition'",
             userTaskKey);
 
     // verify the rejection
@@ -370,6 +395,64 @@ public class UserTaskListenersTest {
         UserTaskIntent.COMPLETING,
         UserTaskIntent.DENY_TASK_LISTENER,
         UserTaskIntent.COMPLETION_DENIED);
+  }
+
+  @Test
+  public void shouldRejectUserTaskAssignmentWhenTaskListenerDeniesTheWork() {
+    // given
+    final var listenerType = "my_listener";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t -> t.zeebeTaskListener(l -> l.assigning().type(listenerType)));
+
+    final JobHandler completeJobHandler =
+        (jobClient, job) ->
+            client
+                .newCompleteCommand(job)
+                .withResult()
+                .deny(true)
+                .denyReason("Reason to deny lifecycle transition")
+                .send()
+                .join();
+    final var recordingHandler = new RecordingJobHandler(completeJobHandler);
+
+    client.newWorker().jobType(listenerType).handler(recordingHandler).open();
+
+    // when: invoke complete user task command
+
+    final CamundaFuture<AssignUserTaskResponse> assignUserTaskFuture =
+        client.newUserTaskAssignCommand(userTaskKey).assignee("john").send();
+
+    // TL job should be successfully completed with the result "denied" set correctly
+    ZeebeAssertHelper.assertJobCompleted(
+        listenerType,
+        userTaskListener -> {
+          assertThat(userTaskListener.getResult().isDenied()).isTrue();
+          assertThat(userTaskListener.getResult().getDeniedReason())
+              .isEqualTo("Reason to deny lifecycle transition");
+        });
+
+    final var rejectionReason =
+        String.format(
+            "Command 'ASSIGN' rejected with code 'INVALID_STATE': Assignment of the User Task with key '%s' was denied by Task Listener. "
+                + "Reason to deny: 'Reason to deny lifecycle transition'",
+            userTaskKey);
+
+    // verify the rejection
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(assignUserTaskFuture::join)
+        .satisfies(
+            ex -> {
+              assertThat(ex.details().getTitle()).isEqualTo(RejectionType.INVALID_STATE.name());
+              assertThat(ex.details().getDetail()).isEqualTo(rejectionReason);
+              assertThat(ex.details().getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            });
+
+    // verify the expected sequence of User Task intents
+    assertUserTaskIntentsSequence(
+        UserTaskIntent.ASSIGNING,
+        UserTaskIntent.DENY_TASK_LISTENER,
+        UserTaskIntent.ASSIGNMENT_DENIED);
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -302,7 +302,7 @@ public class UserTaskListenersTest {
                 .newCompleteCommand(job)
                 .withResult()
                 .deny(true)
-                .denyReason("Reason to deny lifecycle transition")
+                .deniedReason("Reason to deny lifecycle transition")
                 .send()
                 .join();
     client.newWorker().jobType(listenerType).handler(completeJobWithDenialHandler).open();
@@ -354,7 +354,7 @@ public class UserTaskListenersTest {
                 .newCompleteCommand(job)
                 .withResult()
                 .deny(true)
-                .denyReason("Reason to deny lifecycle transition")
+                .deniedReason("Reason to deny lifecycle transition")
                 .send()
                 .join();
     final var recordingHandler = new RecordingJobHandler(completeJobHandler);
@@ -411,7 +411,7 @@ public class UserTaskListenersTest {
                 .newCompleteCommand(job)
                 .withResult()
                 .deny(true)
-                .denyReason("Reason to deny lifecycle transition")
+                .deniedReason("Reason to deny lifecycle transition")
                 .send()
                 .join();
     final var recordingHandler = new RecordingJobHandler(completeJobHandler);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
